### PR TITLE
feat/bullboard

### DIFF
--- a/docker/templates/bullboard/config.yaml
+++ b/docker/templates/bullboard/config.yaml
@@ -9,12 +9,10 @@ containers:
       name: deadly0/bull-board
       use_alpine: false
     env:
-      imported:
-        REDIS_HOST: ${redis.host}
-        REDIS_PORT: ${redis.port}
-        REDIS_PASSWORD: ${redis.password}
+      import:
+        - database
     ports:
-      http: 5000:3000
+      bullboard: 5000:3000
     depends_on:
       - redis
     volumes:

--- a/docker/templates/bullboard/config.yaml
+++ b/docker/templates/bullboard/config.yaml
@@ -1,0 +1,22 @@
+containers:
+  bullboard:
+    stack:
+      - nosql
+      - redis
+      - cache
+      - queue
+    image:
+      name: deadly0/bull-board
+      use_alpine: false
+    env:
+      imported:
+        REDIS_HOST: ${redis.host}
+        REDIS_PORT: ${redis.port}
+        REDIS_PASSWORD: ${redis.password}
+    ports:
+      http: 5000:3000
+    depends_on:
+      - redis
+    volumes:
+      named:
+        data: /tmp/bullboard


### PR DESCRIPTION
**Adding bullboard template**

I'm adding support for the bullboard template, which is a library that abstracts bull, and creates an interface to manage and view the redis queue processes.

References:
[bull-board](https://www.npmjs.com/package/bull-board)
[bull-board-container](https://hub.docker.com/r/deadly0/bull-board)